### PR TITLE
Feature/alternate symbol sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ func main() {
 Some systems don't accept all special characters. You can toggle back and forth between symbol sets like so:
 ```
 password.SetSymbolSetAlternate()
-res, _ := password.Generate(64, 10, 10, false, false)
+res, _ := password.Generate(44, 10, 10, false, false)
 log.Println(res)
 
 password.SetSymbolSetDefault()
-res, _ := password.Generate(64, 10, 10, false, false)
+res, _ := password.Generate(64, 10, 29, false, false)
 log.Println(res)
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ func main() {
 }
 ```
 
+Some systems don't accept all special characters. You can toggle back and forth between symbol sets like so:
+```
+password.SetSymbolSetAlternate()
+res, _ := password.Generate(64, 10, 10, false, false)
+log.Println(res)
+
+password.SetSymbolSetDefault()
+res, _ := password.Generate(64, 10, 10, false, false)
+log.Println(res)
+```
+
+
 See the [GoDoc](https://godoc.org/github.com/sethvargo/go-password) for more
 information.
 

--- a/password/generate.go
+++ b/password/generate.go
@@ -25,9 +25,6 @@ const (
 
 	// Digits is the list of permitted digits.
 	Digits = "0123456789"
-
-	// Symbols is the list of symbols.
-	Symbols = "~!@#$%^&*()_+`-={}|[]\\:\"<>?,./"
 )
 
 var (
@@ -46,7 +43,31 @@ var (
 	// ErrSymbolsExceedsAvailable is the error returned with the number of symbols
 	// exceeds the number of available symbols and repeats are not allowed.
 	ErrSymbolsExceedsAvailable = errors.New("number of symbols exceeds available symbols and repeats are not allowed")
+
+	// symbolSetDefault is a standard set of symbols.
+	symbolSetDefault = "~!@#$%^&*()_+`-={}|[]\\:\"<>?,./"
+
+	// symbolSetAlternate is an alternative list of symbols
+	// supported by systems such as AWS IAM
+	// which allows fewer special characters
+	symbolSetAlternate = "!@#$%^&*()_+-=[]{}|'"
+
+	// symbols holds the pointer to the SymbolSet that will be used during Generate
+	// and is not exported so the user cannot directly alter symbol sets
+	symbols = &symbolSetDefault
 )
+
+// SetSymbolSetAlternate changes the default symbol set to use the AWS IAM friendly
+// symbolSetAlternate of !@#$%^&*()_+-=[]{}|'
+func SetSymbolSetAlternate() {
+	symbols = &symbolSetAlternate
+}
+
+// SetSymbolSetDefault changes the default symbol set to use the symbolSetDefault
+// of ~!@#$%^&*()_+`-={}|[]\:"<>,./
+func SetSymbolSetDefault() {
+	symbols = &symbolSetDefault
+}
 
 // Generate generates a password with the given requirements. length is the
 // total number of characters in the password. numDigits is the number of digits
@@ -75,7 +96,7 @@ func Generate(length, numDigits, numSymbols int, noUpper, allowRepeat bool) (str
 		return "", ErrDigitsExceedsAvailable
 	}
 
-	if !allowRepeat && numSymbols > len(Symbols) {
+	if !allowRepeat && numSymbols > len(*symbols) {
 		return "", ErrSymbolsExceedsAvailable
 	}
 
@@ -117,9 +138,9 @@ func Generate(length, numDigits, numSymbols int, noUpper, allowRepeat bool) (str
 		}
 	}
 
-	// Symbols
+	// symbols
 	for i := 0; i < numSymbols; i++ {
-		sym, err := randomElement(Symbols)
+		sym, err := randomElement(*symbols)
 		if err != nil {
 			return "", err
 		}

--- a/password/generate_test.go
+++ b/password/generate_test.go
@@ -107,9 +107,6 @@ func TestGenerate(t *testing.T) {
 
 	t.Run("gen_no_repeats", func(t *testing.T) {
 		t.Parallel()
-		// make sure the default symbol set is active or the
-		// numSymbols argument will cause a lot of failed test
-		SetSymbolSetDefault()
 
 		for i := 0; i < 10000; i++ {
 			res, err := Generate(52, 10, 29, false, false)

--- a/password/generate_test.go
+++ b/password/generate_test.go
@@ -48,6 +48,27 @@ func TestGenerate(t *testing.T) {
 		}
 	})
 
+	t.Run("contains_no_unwanted_characters", func(t *testing.T) {
+		// these tests can't be run in Parallel due to the toggle
+		SetSymbolSetAlternate()
+		unwantedCharacters := "~`\\:\"<>?,./"
+		for i := 0; i < 100; i++ {
+			pass, err := Generate(40, 9, 20, false, false)
+			if err != nil {
+				t.Errorf("error generating passord '%q'", err)
+			}
+			if strings.ContainsAny(pass, unwantedCharacters) {
+				t.Errorf(
+					"password '%s' contains one or more unwanted characters '%s'",
+					pass,
+					unwantedCharacters,
+				)
+			}
+		}
+		// set back to default so the other tests' arguments are valid
+		SetSymbolSetDefault()
+	})
+
 	t.Run("exceeds_symbols_available", func(t *testing.T) {
 		t.Parallel()
 
@@ -86,9 +107,12 @@ func TestGenerate(t *testing.T) {
 
 	t.Run("gen_no_repeats", func(t *testing.T) {
 		t.Parallel()
+		// make sure the default symbol set is active or the
+		// numSymbols argument will cause a lot of failed test
+		SetSymbolSetDefault()
 
 		for i := 0; i < 10000; i++ {
-			res, err := Generate(52, 10, 30, false, false)
+			res, err := Generate(52, 10, 29, false, false)
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
Here's one way to resolve #3 that addresses your security concern about exporting the `Symbols` string to the user while still maintaining backwards compatibility for the arguments to the `Generate()` function. 

However, this destabilizes the package's behavior if different threads are toggling the symbol set pointer. A better way may be to make the `Generate()` function variadic and accept any number of bools but that's kind of messy. 