### PR TITLE
add note in case of custom password policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Q795Im1VR5h363s48oZGaLDa
 wpvbxlsc
 ```
 
+> Since these are completely randomized, it's possible that they may generate passwords that don't comply with some custom password policies, such as ones that require both upper case AND lower case letters. If your particular use case needs a mix of casing, then you can either increase the number of characters in the password or check the output and regenerate if it fails a particular constraint, such as requiring both upper and lower case.
+
 ## Installation
 
 ```sh


### PR DESCRIPTION
If the use case for generating a password involves a custom password policy that requires both upper and lower case, this generator isn't guaranteed to satisfy that requirement.

Since there's no simple way to ensure that, beyond adding extra complexity to the API, this note should be enough to inform users of the possibility they may need to perform additional checks on any generated passwords.