### PR TITLE
Added some non common chars as ~n on UPPER and lower case chars

### DIFF
--- a/password/generate.go
+++ b/password/generate.go
@@ -32,10 +32,10 @@ type PasswordGenerator interface {
 
 const (
 	// LowerLetters is the list of lowercase letters.
-	LowerLetters = "abcdefghijklmnopqrstuvwxyz"
+	LowerLetters = "abcdefghijklmnñopqrstuvwxyz"
 
 	// UpperLetters is the list of uppercase letters.
-	UpperLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	UpperLetters = "ABCDEFGHIJKLMNÑOPQRSTUVWXYZ"
 
 	// Digits is the list of permitted digits.
 	Digits = "0123456789"


### PR DESCRIPTION
Added some non common chars as ~n on UPPER and lower case chars. Just in case. The sample space is greater, then, is more improbable to use them. And, as this practice is not that common on other languages, it is also preventing some brute-force and dictionary attacks.